### PR TITLE
feat: introduce match status management and start match functionality

### DIFF
--- a/backend/internal/database/migrations/007_update_matches_status_constraint.sql
+++ b/backend/internal/database/migrations/007_update_matches_status_constraint.sql
@@ -1,0 +1,12 @@
+-- Update matches status constraint to include 'not_started'
+-- This migration updates the existing constraint to allow the new status
+
+-- Drop the existing constraint
+ALTER TABLE testing_db.matches DROP CONSTRAINT IF EXISTS matches_status_check;
+
+-- Add the new constraint with 'not_started' included
+ALTER TABLE testing_db.matches ADD CONSTRAINT matches_status_check 
+CHECK (status IN ('not_started', 'live', 'completed', 'cancelled'));
+
+-- Update the default value to 'not_started' for new matches
+ALTER TABLE testing_db.matches ALTER COLUMN status SET DEFAULT 'not_started';

--- a/backend/internal/models/match.go
+++ b/backend/internal/models/match.go
@@ -8,9 +8,10 @@ import (
 type MatchStatus string
 
 const (
-	MatchStatusLive      MatchStatus = "live"
-	MatchStatusCompleted MatchStatus = "completed"
-	MatchStatusCancelled MatchStatus = "cancelled"
+	MatchStatusNotStarted MatchStatus = "not_started"
+	MatchStatusLive       MatchStatus = "live"
+	MatchStatusCompleted  MatchStatus = "completed"
+	MatchStatusCancelled  MatchStatus = "cancelled"
 )
 
 // TossType represents the toss result
@@ -63,7 +64,7 @@ type CreateMatchRequest struct {
 type UpdateMatchRequest struct {
 	MatchNumber      *int         `json:"match_number,omitempty" validate:"omitempty,min=1"`
 	Date             *time.Time   `json:"date,omitempty"`
-	Status           *MatchStatus `json:"status,omitempty" validate:"omitempty,oneof=live completed cancelled"`
+	Status           *MatchStatus `json:"status,omitempty" validate:"omitempty,oneof=not_started live completed cancelled"`
 	TeamAPlayerCount *int         `json:"team_a_player_count,omitempty" validate:"omitempty,min=1,max=20"`
 	TeamBPlayerCount *int         `json:"team_b_player_count,omitempty" validate:"omitempty,min=1,max=20"`
 	TotalOvers       *int         `json:"total_overs,omitempty" validate:"omitempty,min=1,max=20"`

--- a/backend/internal/services/container.go
+++ b/backend/internal/services/container.go
@@ -9,10 +9,11 @@ import (
 
 // Container holds all service instances
 type Container struct {
-	DBClient  *database.Client
-	Series    *SeriesService
-	Match     *MatchService
-	Scorecard interfaces.ScorecardServiceInterface
+	DBClient   *database.Client
+	Series     *SeriesService
+	Match      *MatchService
+	MatchState MatchStateServiceInterface
+	Scorecard  interfaces.ScorecardServiceInterface
 	// Authentication services
 	AuthService    *AuthService
 	SessionService *SessionService
@@ -32,12 +33,21 @@ func NewContainer(dbClient *database.Client, cfg *config.Config) *Container {
 	sessionService := NewSessionService(dbClient.Repositories.User, cfg)
 	authService := NewAuthService(cfg, dbClient.Repositories.User, sessionService)
 
+	// Create match state service
+	matchStateService := NewMatchStateService(
+		dbClient.Repositories.Match,
+		dbClient.Repositories.Scoreboard,
+		dbClient.Repositories.Over,
+		dbClient.Repositories.Ball,
+	)
+
 	// Create container
 	container := &Container{
-		DBClient:  dbClient,
-		Series:    NewSeriesService(dbClient.Repositories.Series),
-		Match:     NewMatchService(dbClient.Repositories.Match, dbClient.Repositories.Series),
-		Scorecard: scorecardService,
+		DBClient:   dbClient,
+		Series:     NewSeriesService(dbClient.Repositories.Series),
+		Match:      NewMatchService(dbClient.Repositories.Match, dbClient.Repositories.Series),
+		MatchState: matchStateService,
+		Scorecard:  scorecardService,
 		// Authentication services
 		AuthService:    authService,
 		SessionService: sessionService,

--- a/backend/internal/services/match_service.go
+++ b/backend/internal/services/match_service.go
@@ -83,7 +83,7 @@ func (s *MatchService) CreateMatch(ctx context.Context, req *models.CreateMatchR
 		SeriesID:         req.SeriesID,
 		MatchNumber:      matchNumber,
 		Date:             req.Date,
-		Status:           models.MatchStatusLive, // Always live by default
+		Status:           models.MatchStatusNotStarted, // Not started by default
 		TeamAPlayerCount: req.TeamAPlayerCount,
 		TeamBPlayerCount: req.TeamBPlayerCount,
 		TotalOvers:       req.TotalOvers,

--- a/backend/internal/services/match_state_service.go
+++ b/backend/internal/services/match_state_service.go
@@ -31,7 +31,7 @@ func NewMatchStateService(
 	}
 }
 
-// StartMatch starts a match (changes status from scheduled to live)
+// StartMatch starts a match (changes status from not_started to live)
 func (s *MatchStateService) StartMatch(ctx context.Context, matchID string) (*models.Match, error) {
 	if matchID == "" {
 		return nil, fmt.Errorf("match ID is required")
@@ -42,8 +42,13 @@ func (s *MatchStateService) StartMatch(ctx context.Context, matchID string) (*mo
 		return nil, fmt.Errorf("match not found: %w", err)
 	}
 
-	// Matches are now always live by default, so no need to check status
-	// Just return the match as is
+	// Check if match is in not_started status
+	if match.Status != models.MatchStatusNotStarted {
+		return nil, fmt.Errorf("match must be not started to begin")
+	}
+
+	// Change status to live
+	match.Status = models.MatchStatusLive
 	match.UpdatedAt = time.Now()
 
 	err = s.matchRepo.Update(ctx, matchID, match)

--- a/backend/internal/services/match_state_service_interface.go
+++ b/backend/internal/services/match_state_service_interface.go
@@ -1,0 +1,14 @@
+package services
+
+import (
+	"context"
+	"spark-park-cricket-backend/internal/models"
+)
+
+// MatchStateServiceInterface defines the interface for match state operations
+type MatchStateServiceInterface interface {
+	StartMatch(ctx context.Context, matchID string) (*models.Match, error)
+	CompleteMatch(ctx context.Context, matchID string) (*models.Match, error)
+	CancelMatch(ctx context.Context, matchID string) (*models.Match, error)
+	GetMatchSummary(ctx context.Context, matchID string) (*MatchSummary, error)
+}

--- a/backend/internal/services/scorecard_service.go
+++ b/backend/internal/services/scorecard_service.go
@@ -121,9 +121,23 @@ func (s *ScorecardService) StartScoring(ctx context.Context, matchID string) err
 		return fmt.Errorf("access denied: you can only start scoring for matches in series you created")
 	}
 
-	// Check if match is live
-	if match.Status != models.MatchStatusLive {
-		return fmt.Errorf("match is not live, cannot start scoring")
+	// Check if match is not_started or live
+	if match.Status != models.MatchStatusNotStarted && match.Status != models.MatchStatusLive {
+		return fmt.Errorf("match must be not started or live to begin scoring")
+	}
+
+	// If match is not_started, transition it to live
+	if match.Status == models.MatchStatusNotStarted {
+		match.Status = models.MatchStatusLive
+		match.UpdatedAt = time.Now()
+
+		err = s.matchRepo.Update(ctx, matchID, match)
+		if err != nil {
+			log.Printf("Error updating match status: %v", err)
+			return fmt.Errorf("failed to start match: %w", err)
+		}
+
+		log.Printf("Match %s status changed from not_started to live", matchID)
 	}
 
 	// Check if scoring is already started

--- a/backend/internal/utils/enums.go
+++ b/backend/internal/utils/enums.go
@@ -4,10 +4,10 @@ package utils
 type MatchStatus string
 
 const (
-	MatchStatusScheduled MatchStatus = "scheduled"
-	MatchStatusLive      MatchStatus = "live"
-	MatchStatusCompleted MatchStatus = "completed"
-	MatchStatusCancelled MatchStatus = "cancelled"
+	MatchStatusNotStarted MatchStatus = "not_started"
+	MatchStatusLive       MatchStatus = "live"
+	MatchStatusCompleted  MatchStatus = "completed"
+	MatchStatusCancelled  MatchStatus = "cancelled"
 )
 
 // BallType represents the type of ball in cricket
@@ -23,7 +23,7 @@ const (
 // IsValidMatchStatus checks if the status is valid
 func IsValidMatchStatus(status string) bool {
 	switch MatchStatus(status) {
-	case MatchStatusScheduled, MatchStatusLive, MatchStatusCompleted, MatchStatusCancelled:
+	case MatchStatusNotStarted, MatchStatusLive, MatchStatusCompleted, MatchStatusCancelled:
 		return true
 	default:
 		return false
@@ -43,7 +43,7 @@ func IsValidBallType(ballType string) bool {
 // GetValidMatchStatuses returns all valid match statuses
 func GetValidMatchStatuses() []string {
 	return []string{
-		string(MatchStatusScheduled),
+		string(MatchStatusNotStarted),
 		string(MatchStatusLive),
 		string(MatchStatusCompleted),
 		string(MatchStatusCancelled),

--- a/web/src/components/MatchForm.tsx
+++ b/web/src/components/MatchForm.tsx
@@ -133,7 +133,7 @@ export function MatchForm({
     > = {
       series_id: formData.series_id,
       date: `${formData.date}T00:00:00Z`,
-      status: 'live' as const,
+      status: 'not_started' as const,
       team_a_player_count: formData.team_player_count,
       team_b_player_count: formData.team_player_count,
       total_overs: formData.total_overs,

--- a/web/src/components/SeriesWithMatches.tsx
+++ b/web/src/components/SeriesWithMatches.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   fetchMatchesBySeriesRequest,
   deleteMatchRequest,
+  startMatchRequest,
   Match,
 } from '@/store/reducers/matchSlice';
 import { useCompletedMatchesCache } from '@/hooks/useCompletedMatchesCache';
@@ -94,12 +95,12 @@ export function SeriesWithMatches({
     async (matchId: string) => {
       // Check if data exists in cache and is not expired
       const cachedData = getCachedData(matchId);
-      
+
       if (cachedData) {
-        // Use cached data
+        // Use cached data - cast to ScorecardData since we know it's the right type
         setScorecardData(prev => ({
           ...prev,
-          [matchId]: cachedData,
+          [matchId]: cachedData as ScorecardData,
         }));
         return;
       }
@@ -170,6 +171,12 @@ export function SeriesWithMatches({
     }
   };
 
+  const handleStartMatch = (id: string) => {
+    if (window.confirm('Are you sure you want to start this match?')) {
+      dispatch(startMatchRequest(id));
+    }
+  };
+
   const handleEditMatch = (match: Match) => {
     setEditingMatch(match);
     setShowMatchForm(true);
@@ -189,23 +196,23 @@ export function SeriesWithMatches({
   // Smart refresh that respects cache
   const handleSmartRefresh = () => {
     console.log('🔄 Smart Refresh - Checking cache for completed matches');
-    
+
     // Always refresh matches list (this is lightweight)
     dispatch(fetchMatchesBySeriesRequest(series.id));
-    
+
     // Only fetch scorecard data for completed matches that aren't cached
     if (seriesMatches.length > 0) {
       const completedMatches = seriesMatches.filter(match => match.status === 'completed');
       const cachedMatches = completedMatches.filter(match => isCached(match.id));
       const uncachedMatches = completedMatches.filter(match => !isCached(match.id));
-      
+
       console.log(`📊 Cache Status: ${cachedMatches.length} cached, ${uncachedMatches.length} need API call`);
-      
+
       uncachedMatches.forEach(match => {
         console.log(`🌐 API Call needed for match ${match.id} (${match.match_number})`);
         fetchMatchScorecard(match.id);
       });
-      
+
       if (cachedMatches.length > 0) {
         console.log(`✅ Using cache for matches: ${cachedMatches.map(m => m.match_number).join(', ')}`);
       }
@@ -215,15 +222,15 @@ export function SeriesWithMatches({
   // Force refresh that bypasses cache
   const handleForceRefresh = () => {
     console.log('🔄 Force Refresh - Bypassing cache for all completed matches');
-    
+
     // Always refresh matches list
     dispatch(fetchMatchesBySeriesRequest(series.id));
-    
+
     // Force fetch scorecard data for all completed matches (bypass cache)
     if (seriesMatches.length > 0) {
       const completedMatches = seriesMatches.filter(match => match.status === 'completed');
       console.log(`🌐 Force API calls for ${completedMatches.length} completed matches`);
-      
+
       completedMatches.forEach(match => {
         console.log(`🔄 Force refreshing match ${match.id} (${match.match_number})`);
         // Clear cache for this match first
@@ -304,7 +311,7 @@ export function SeriesWithMatches({
                 {expanded && (
                   <>
                     <div className="border-t border-gray-200 my-1"></div>
-                    <DropdownMenuItem 
+                    <DropdownMenuItem
                       onClick={handleSmartRefresh}
                       disabled={matchesLoading}
                       data-cy="refresh-matches-button"
@@ -312,7 +319,7 @@ export function SeriesWithMatches({
                       <RefreshCw className={`h-4 w-4 mr-2 ${matchesLoading ? 'animate-spin' : ''}`} />
                       Smart Refresh (Cache)
                     </DropdownMenuItem>
-                    <DropdownMenuItem 
+                    <DropdownMenuItem
                       onClick={handleForceRefresh}
                       disabled={matchesLoading}
                       data-cy="force-refresh-button"
@@ -454,17 +461,21 @@ export function SeriesWithMatches({
                                   ? 'default'
                                   : match.status === 'completed'
                                     ? 'secondary'
-                                    : 'outline'
+                                    : match.status === 'not_started'
+                                      ? 'outline'
+                                      : 'outline'
                               }
                               className={
                                 match.status === 'live'
                                   ? 'bg-green-500 text-white border-green-500 font-semibold'
                                   : match.status === 'completed'
                                     ? 'bg-gray-100 text-gray-800 border-gray-200 font-semibold'
-                                    : 'bg-yellow-100 text-yellow-800 border-yellow-200 font-semibold'
+                                    : match.status === 'not_started'
+                                      ? 'bg-blue-100 text-blue-800 border-blue-200 font-semibold'
+                                      : 'bg-yellow-100 text-yellow-800 border-yellow-200 font-semibold'
                               }
                             >
-                              {match.status.toUpperCase()}
+                              {match.status === 'not_started' ? 'NOT STARTED' : match.status.toUpperCase()}
                             </Badge>
                           </div>
 
@@ -624,6 +635,15 @@ export function SeriesWithMatches({
                             </DropdownMenuItem>
                             {isOwner && (
                               <>
+                                {match.status === 'not_started' && (
+                                  <DropdownMenuItem
+                                    onClick={() => handleStartMatch(match.id)}
+                                    className="text-green-600 focus:text-green-600"
+                                  >
+                                    <Play className="h-4 w-4 mr-2" />
+                                    Start Match
+                                  </DropdownMenuItem>
+                                )}
                                 <DropdownMenuItem
                                   onClick={() => handleEditMatch(match)}
                                 >

--- a/web/src/hooks/useCompletedMatchesCache.ts
+++ b/web/src/hooks/useCompletedMatchesCache.ts
@@ -15,18 +15,18 @@ export const useCompletedMatchesCache = () => {
     (matchId: string) => {
       const cachedData = completedMatchesCache[matchId];
       const now = Date.now();
-      
+
       if (cachedData && cachedData.expiresAt > now) {
         return cachedData.data;
       }
-      
+
       return null;
     },
     [completedMatchesCache]
   );
 
   const setCachedData = useCallback(
-    (matchId: string, data: any, cacheDuration = 10 * 60 * 1000) => {
+    (matchId: string, data: unknown, cacheDuration = 10 * 60 * 1000) => {
       dispatch(cacheCompletedMatchData({
         matchId,
         data,

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -267,6 +267,13 @@ class ApiService {
     });
   }
 
+  async startMatch(id: string): Promise<ApiResponse<{ message: string; match_id: string }>> {
+    return this.request<{ message: string; match_id: string }>('/scorecard/start', {
+      method: 'POST',
+      body: JSON.stringify({ match_id: id }),
+    });
+  }
+
   async getMatchesBySeries(seriesId: string): Promise<ApiResponse<Match[]>> {
     return this.request<Match[]>(`/matches/series/${seriesId}`);
   }

--- a/web/src/store/reducers/matchSlice.ts
+++ b/web/src/store/reducers/matchSlice.ts
@@ -6,7 +6,7 @@ export interface Match {
   series_id: string;
   match_number: number;
   date: string;
-  status: 'live' | 'completed' | 'cancelled';
+  status: 'not_started' | 'live' | 'completed' | 'cancelled';
   team_a_player_count: number;
   team_b_player_count: number;
   total_overs: number;
@@ -25,7 +25,7 @@ interface MatchState {
   // Cache for completed matches scorecard data
   completedMatchesCache: {
     [matchId: string]: {
-      data: any;
+      data: unknown;
       timestamp: number;
       expiresAt: number;
     };
@@ -120,12 +120,31 @@ export const matchSlice = createSlice({
       state.loading = false;
       state.error = action.payload;
     },
+    startMatchRequest: (state, _action: PayloadAction<string>) => {
+      state.loading = true;
+      state.error = null;
+    },
+    startMatchSuccess: (state, action: PayloadAction<Match>) => {
+      state.loading = false;
+      const index = state.matches.findIndex(
+        match => match.id === action.payload.id
+      );
+      if (index !== -1 && state.matches[index]) {
+        // Update only the status and updated_at fields
+        state.matches[index].status = action.payload.status;
+        state.matches[index].updated_at = action.payload.updated_at;
+      }
+    },
+    startMatchFailure: (state, action: PayloadAction<string>) => {
+      state.loading = false;
+      state.error = action.payload;
+    },
     // Cache management for completed matches
     cacheCompletedMatchData: (
       state,
       action: PayloadAction<{
         matchId: string;
-        data: any;
+        data: unknown;
         cacheDuration?: number; // in milliseconds, default 5 minutes
       }>
     ) => {
@@ -140,7 +159,8 @@ export const matchSlice = createSlice({
     clearExpiredCache: (state) => {
       const now = Date.now();
       Object.keys(state.completedMatchesCache).forEach(matchId => {
-        if (state.completedMatchesCache[matchId].expiresAt < now) {
+        const cacheEntry = state.completedMatchesCache[matchId];
+        if (cacheEntry && cacheEntry.expiresAt < now) {
           delete state.completedMatchesCache[matchId];
         }
       });
@@ -169,6 +189,9 @@ export const {
   deleteMatchRequest,
   deleteMatchSuccess,
   deleteMatchFailure,
+  startMatchRequest,
+  startMatchSuccess,
+  startMatchFailure,
   cacheCompletedMatchData,
   clearExpiredCache,
   clearMatchCache,

--- a/web/src/store/sagas/matchSaga.ts
+++ b/web/src/store/sagas/matchSaga.ts
@@ -20,6 +20,9 @@ import {
   deleteMatchRequest,
   deleteMatchSuccess,
   deleteMatchFailure,
+  startMatchRequest,
+  startMatchSuccess,
+  startMatchFailure,
 } from '../reducers/matchSlice';
 import { ApiService, ApiError, ApiResponse } from '@/services/api';
 import { Match } from '../reducers/matchSlice';
@@ -117,10 +120,30 @@ export function* deleteMatchSaga(
   }
 }
 
+export function* startMatchSaga(
+  action: ReturnType<typeof startMatchRequest>
+): Generator<CallEffect | PutEffect, void, ApiResponse<{ message: string; match_id: string }>> {
+  try {
+    const apiService = new ApiService();
+    yield call(
+      apiService.startMatch.bind(apiService),
+      action.payload
+    );
+
+    // Just dispatch success with the match ID - the reducer will handle the status update
+    yield put(startMatchSuccess({ id: action.payload, status: 'live' } as Match));
+  } catch (error) {
+    const errorMessage =
+      error instanceof ApiError ? error.message : 'Failed to start match';
+    yield put(startMatchFailure(errorMessage));
+  }
+}
+
 export function* matchSaga() {
   yield takeLatest(fetchMatchesRequest.type, fetchMatchesSaga);
   yield takeLatest(fetchMatchesBySeriesRequest.type, fetchMatchesBySeriesSaga);
   yield takeEvery(createMatchRequest.type, createMatchSaga);
   yield takeEvery(updateMatchRequest.type, updateMatchSaga);
   yield takeEvery(deleteMatchRequest.type, deleteMatchSaga);
+  yield takeEvery(startMatchRequest.type, startMatchSaga);
 }


### PR DESCRIPTION
- Added a new match status 'not_started' to the MatchStatus enum.
- Updated CreateMatchRequest to default to 'not_started' status.
- Implemented MatchStateService to manage match state transitions, including starting a match.
- Enhanced scoring logic to transition match status from 'not_started' to 'live' when scoring begins.
- Updated frontend components to reflect the new match status and allow starting matches.
- Improved validation and error handling for match state changes.