### PR TITLE
feat: add start and end time fields to Match model and update related…

### DIFF
--- a/backend/internal/database/migrations/008_add_match_timing_fields.sql
+++ b/backend/internal/database/migrations/008_add_match_timing_fields.sql
@@ -1,0 +1,30 @@
+-- Add match timing fields to matches table
+-- This migration adds start_time and end_time columns to track match duration
+-- Version: 8.0.0
+-- Date: 2025-10-05
+
+-- ============================================
+-- MATCH TIMING FIELDS
+-- ============================================
+
+-- Add start_time column to track when match started
+ALTER TABLE testing_db.matches 
+ADD COLUMN IF NOT EXISTS start_time TIMESTAMP WITH TIME ZONE;
+
+-- Add end_time column to track when match ended
+ALTER TABLE testing_db.matches 
+ADD COLUMN IF NOT EXISTS end_time TIMESTAMP WITH TIME ZONE;
+
+-- Add comments for documentation
+COMMENT ON COLUMN testing_db.matches.start_time IS 'Timestamp when the match started (set when status changes to live)';
+COMMENT ON COLUMN testing_db.matches.end_time IS 'Timestamp when the match ended (set when status changes to completed)';
+
+-- Create index on start_time for performance
+CREATE INDEX IF NOT EXISTS idx_matches_start_time ON testing_db.matches(start_time);
+
+-- Create index on end_time for performance  
+CREATE INDEX IF NOT EXISTS idx_matches_end_time ON testing_db.matches(end_time);
+
+-- Create composite index for timing queries
+CREATE INDEX IF NOT EXISTS idx_matches_timing ON testing_db.matches(start_time, end_time) 
+WHERE start_time IS NOT NULL OR end_time IS NOT NULL;

--- a/backend/internal/models/match.go
+++ b/backend/internal/models/match.go
@@ -43,6 +43,8 @@ type Match struct {
 	TossWinner       TeamType    `json:"toss_winner" db:"toss_winner"`
 	TossType         TossType    `json:"toss_type" db:"toss_type"`
 	BattingTeam      TeamType    `json:"batting_team" db:"batting_team"`
+	StartTime        *time.Time  `json:"start_time,omitempty" db:"start_time,omitempty"`
+	EndTime          *time.Time  `json:"end_time,omitempty" db:"end_time,omitempty"`
 	CreatedBy        string      `json:"created_by,omitempty" db:"created_by,omitempty"`
 	CreatedAt        time.Time   `json:"created_at" db:"created_at"`
 	UpdatedAt        time.Time   `json:"updated_at" db:"updated_at"`

--- a/backend/internal/repository/supabase/match_repository.go
+++ b/backend/internal/repository/supabase/match_repository.go
@@ -148,6 +148,15 @@ func (r *matchRepository) Update(ctx context.Context, id string, match *models.M
 		"updated_at":          match.UpdatedAt,
 	}
 
+	// Add timing fields if they exist
+	if match.StartTime != nil {
+		matchData["start_time"] = match.StartTime
+	}
+	if match.EndTime != nil {
+		matchData["end_time"] = match.EndTime
+	}
+
+
 	// Only include created_by if it's not empty
 	if match.CreatedBy != "" {
 		matchData["created_by"] = match.CreatedBy

--- a/backend/internal/services/match_state_service.go
+++ b/backend/internal/services/match_state_service.go
@@ -74,8 +74,10 @@ func (s *MatchStateService) CompleteMatch(ctx context.Context, matchID string) (
 		return nil, fmt.Errorf("match must be live to complete")
 	}
 
+	now := time.Now()
 	match.Status = models.MatchStatusCompleted
-	match.UpdatedAt = time.Now()
+	match.EndTime = &now
+	match.UpdatedAt = now
 
 	err = s.matchRepo.Update(ctx, matchID, match)
 	if err != nil {

--- a/backend/internal/services/scorecard_service.go
+++ b/backend/internal/services/scorecard_service.go
@@ -128,8 +128,10 @@ func (s *ScorecardService) StartScoring(ctx context.Context, matchID string) err
 
 	// If match is not_started, transition it to live
 	if match.Status == models.MatchStatusNotStarted {
+		now := time.Now()
 		match.Status = models.MatchStatusLive
-		match.UpdatedAt = time.Now()
+		match.StartTime = &now
+		match.UpdatedAt = now
 
 		err = s.matchRepo.Update(ctx, matchID, match)
 		if err != nil {
@@ -137,7 +139,7 @@ func (s *ScorecardService) StartScoring(ctx context.Context, matchID string) err
 			return fmt.Errorf("failed to start match: %w", err)
 		}
 
-		log.Printf("Match %s status changed from not_started to live", matchID)
+		log.Printf("Match %s status changed from not_started to live at %s", matchID, now.Format(time.RFC3339))
 	}
 
 	// Check if scoring is already started
@@ -453,7 +455,10 @@ func (s *ScorecardService) AddBallOptimized(ctx context.Context, req *models.Bal
 				return fmt.Errorf("failed to fetch match data: %w", err)
 			}
 
+			now := time.Now()
 			completeMatch.Status = models.MatchStatusCompleted
+			completeMatch.EndTime = &now
+			completeMatch.UpdatedAt = now
 			err = s.matchRepo.Update(ctx, req.MatchID, completeMatch)
 			if err != nil {
 				return fmt.Errorf("failed to complete match: %w", err)
@@ -785,12 +790,15 @@ func (s *ScorecardService) AddBallLegacy(ctx context.Context, req *models.BallEv
 			}
 
 			// Complete the match
+			now := time.Now()
 			match.Status = models.MatchStatusCompleted
+			match.EndTime = &now
+			match.UpdatedAt = now
 			err = s.matchRepo.Update(ctx, req.MatchID, match)
 			if err != nil {
 				return fmt.Errorf("failed to complete match: %w", err)
 			}
-			log.Printf("Match %s completed - %s", req.MatchID, reason)
+			log.Printf("Match %s completed at %s - %s", req.MatchID, now.Format(time.RFC3339), reason)
 		}
 	}
 

--- a/web/src/components/SeriesWithMatches.tsx
+++ b/web/src/components/SeriesWithMatches.tsx
@@ -525,6 +525,45 @@ export function SeriesWithMatches({
                             </p>
                           </div>
 
+                          {/* Match Timing Information */}
+                          {(match.start_time || match.end_time) && (
+                            <div className="bg-green-50 rounded-lg p-3 border border-green-100">
+                              <div className="flex items-center space-x-2 mb-2">
+                                <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                                <span className="text-xs font-medium text-green-600 uppercase tracking-wide">
+                                  Match Timing
+                                </span>
+                              </div>
+                              <div className="space-y-1">
+                                {match.start_time && (
+                                  <p className="text-sm text-green-800">
+                                    <span className="font-medium">Started:</span>{' '}
+                                    {new Date(match.start_time).toLocaleString()}
+                                  </p>
+                                )}
+                                {match.end_time && (
+                                  <p className="text-sm text-green-800">
+                                    <span className="font-medium">Ended:</span>{' '}
+                                    {new Date(match.end_time).toLocaleString()}
+                                  </p>
+                                )}
+                                {match.start_time && match.end_time && (
+                                  <p className="text-sm font-semibold text-green-900">
+                                    <span className="font-medium">Duration:</span>{' '}
+                                    {(() => {
+                                      const start = new Date(match.start_time);
+                                      const end = new Date(match.end_time);
+                                      const duration = end.getTime() - start.getTime();
+                                      const hours = Math.floor(duration / (1000 * 60 * 60));
+                                      const minutes = Math.floor((duration % (1000 * 60 * 60)) / (1000 * 60));
+                                      return `${hours}h ${minutes}m`;
+                                    })()}
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                          )}
+
                           {/* Match Completion Summary */}
                           {match.status === 'completed' &&
                             (() => {

--- a/web/src/store/reducers/matchSlice.ts
+++ b/web/src/store/reducers/matchSlice.ts
@@ -13,6 +13,8 @@ export interface Match {
   toss_winner: 'A' | 'B';
   toss_type: 'H' | 'T';
   batting_team: 'A' | 'B';
+  start_time?: string;
+  end_time?: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
… services

- Introduced `start_time` and `end_time` fields to the Match model for tracking match timings.
- Updated match state service to set `start_time` when a match starts and `end_time` when it completes.
- Enhanced scorecard service to reflect match timing updates.
- Modified SeriesWithMatches component to display match timing information, including duration calculation.